### PR TITLE
Switched from rpi-433 to rpi-433-v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # node-red-contrib-rpi-433
 
-A Node-Red node to sniff and emit codes on the 433 mhz frequency. It wraps the [rpi-433](https://github.com/eroak/rpi-433) library.
+A Node-Red node to sniff and emit codes on the 433 mhz frequency. It wraps the [rpi-433-v2](https://github.com/kjetilhp/rpi-433) library.
 
 ## Install
 
 ```
+sudo apt install wiringpi
 cd ~\.node-red
 npm install node-red-contrib-rpi-433
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
-    "rpi-433": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/rpi-433/-/rpi-433-2.1.0.tgz",
-      "integrity": "sha1-zyAVtpMHjDKPiGkyxq0iHJSptB0=",
+    "rpi-433-v2": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rpi-433-v2/-/rpi-433-v2-1.0.3.tgz",
+      "integrity": "sha512-VvkcZBEP4KSs3rZ6b+In77IT8s6pAnU1Qy8FbVHmHYORgf3Wj2GUIvJo5fIvVljELh3QlnUZCyyjsCFnGePuOA==",
       "requires": {
-        "q": "^1.4.1",
-        "underscore": "^1.8.3"
+        "q": "^1.5.1",
+        "underscore": "^1.9.1"
       }
     },
     "underscore": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     },
     "homepage": "https://github.com/jmc265/node-red-contrib-rpi-433#readme",
     "dependencies": {
-        "rpi-433": "^2.1.0"
+        "rpi-433-v2": "~1.0.3"
     }
 }

--- a/src/rpi-433-emitter.js
+++ b/src/rpi-433-emitter.js
@@ -1,4 +1,4 @@
-var rpi433 = require('rpi-433');
+var rpi433 = require('rpi-433-v2');
 
 module.exports = function (RED) {
     function Rpi433Emitter(config) {

--- a/src/rpi-433-sniffer.js
+++ b/src/rpi-433-sniffer.js
@@ -1,4 +1,4 @@
-var rpi433 = require('rpi-433');
+var rpi433 = require('rpi-433-v2');
 
 module.exports = function (RED) {
     function Rpi433Sniffer(config) {


### PR DESCRIPTION
When I tried installing your node, I was getting compilation errors for rpi-433. Turns out that library hasn't been updated in a while, but there are some forks w/ minor updates. The one I've changed it to is published to NPM and seems to at least compile.

I've also added a note to the README for installing wiringPi, though I suppose for those w/ a RPi 4B (like myself), they'll have to follow these instructions: http://wiringpi.com/wiringpi-updated-to-2-52-for-the-raspberry-pi-4b/